### PR TITLE
docs: add two issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue--title.md
+++ b/.github/ISSUE_TEMPLATE/issue--title.md
@@ -1,0 +1,10 @@
+---
+name: 'Issue: Title'
+about: If you're facing any issues, bug, or whatever, choose this template.
+title: ''
+labels: new
+assignees: ''
+
+---
+
+An empty canvas! Remove this line and show your creativity.

--- a/.github/ISSUE_TEMPLATE/rfc--title.md
+++ b/.github/ISSUE_TEMPLATE/rfc--title.md
@@ -1,0 +1,20 @@
+---
+name: 'RFC: Title'
+about: Suggest an idea for this project
+title: ''
+labels: RFC, new
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
add one issue template for RFCs - new feature requests
add one issue template for common issues like a bug report, etc.

close #27 